### PR TITLE
feat: adding fail on error flag

### DIFF
--- a/.github/workflows/verify-pr.yaml
+++ b/.github/workflows/verify-pr.yaml
@@ -15,8 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
-  verify:
+  verify-standard:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
@@ -25,6 +24,8 @@ jobs:
       - name: Run Cimon
         uses: ./
         with:
+          client-id: ${{ secrets.CIMON_CLIENT_ID }}
+          secret: ${{ secrets.CIMON_SECRET }}
           prevent: true
           allowed-hosts: >
             cycode.com,
@@ -35,3 +36,16 @@ jobs:
           curl -I https://api.github.com
           curl -I https://cycode.com
           wget --quiet --timeout 1 https://registry.npmjs.org || true
+
+  verify-fail-on-error:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Run Cimon
+        uses: ./
+        with:
+          client-id: ${{ secrets.CIMON_CLIENT_ID }}
+          secret: ${{ secrets.CIMON_SECRET }}
+          allowed-hosts: this,would,^$#yield,error

--- a/action.yaml
+++ b/action.yaml
@@ -57,6 +57,11 @@ inputs:
   feature-gates:
     description: Set of key=value pairs that describe Cimon features.
     required: false
+  fail-on-error:
+    description: Fail the CI if Cimon encountered an error
+    required: false
+    default: "false"
+
 runs:
   using: node16
   main: "dist/main/index.js"

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -4256,7 +4256,7 @@ async function run(config) {
     });
 
     if (exitCode !== 0) {
-        throw new Error('Failed starting Cimon container');
+        throw new Error('Failed executing docker run command for Cimon container');
     }
 
     const health = await (0,_poll_poll_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"] */ .Z)(async () => {
@@ -4269,7 +4269,7 @@ async function run(config) {
 
     if (health.Status !== _docker_docker_js__WEBPACK_IMPORTED_MODULE_2__/* ["default"].CONTAINER_STATUS_HEALTHY */ .Z.CONTAINER_STATUS_HEALTHY) {
         const log = health.Log;
-        let message = 'Failed starting Cimon container';
+        let message = 'Failed reaching healthy container status for Cimon container';
         if (Array.isArray(log) && log.length > 0) {
             const latestEntry = log[0];
             message += `: exit code: ${latestEntry.ExitCode}: ${latestEntry.Output}`;
@@ -4283,7 +4283,11 @@ async function run(config) {
 try {
     await run(getActionConfig());
 } catch (error) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(error.message);
+    const failOnError = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput('fail-on-error');
+    const log = error.message;
+    if (failOnError) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(log);
+    }
 }
 __webpack_handle_async_dependencies__();
 }, 1);

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -11008,6 +11008,10 @@ async function run(config) {
         return state.Status !== _docker_docker_js__WEBPACK_IMPORTED_MODULE_3__/* ["default"].CONTAINER_STATUS_EXITED */ .Z.CONTAINER_STATUS_EXITED;
     }, 1000, 30 * 1000);
 
+    if (logs.stderr !== '') {
+        throw new Error(logs.stderr);
+    }
+
     if (containerState.ExitCode !== 0) {
         throw new Error(`Container exited with error: ${containerState.ExitCode}`);
     }
@@ -11018,7 +11022,16 @@ async function run(config) {
 try {
     await run(getActionConfig());
 } catch (error) {
-    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(error.message);
+    const failOnError = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput('fail-on-error');
+    const log = error.message;
+    if (failOnError) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(log);
+    } else {
+        await _actions_core__WEBPACK_IMPORTED_MODULE_0__.summary.addHeading('Cimon Security Report - Failure')
+            .addRaw('Cimon encountered an error and was shut down due to the "fail-on-error=false" flag. Details of the error are below:')
+            .addCodeBlock(log)
+            .write()
+    }
 }
 __webpack_handle_async_dependencies__();
 }, 1);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -140,7 +140,7 @@ async function run(config) {
     });
 
     if (exitCode !== 0) {
-        throw new Error('Failed starting Cimon container');
+        throw new Error('Failed executing docker run command for Cimon container');
     }
 
     const health = await poll(async () => {
@@ -153,7 +153,7 @@ async function run(config) {
 
     if (health.Status !== docker.CONTAINER_STATUS_HEALTHY) {
         const log = health.Log;
-        let message = 'Failed starting Cimon container';
+        let message = 'Failed reaching healthy container status for Cimon container';
         if (Array.isArray(log) && log.length > 0) {
             const latestEntry = log[0];
             message += `: exit code: ${latestEntry.ExitCode}: ${latestEntry.Output}`;
@@ -167,5 +167,9 @@ async function run(config) {
 try {
     await run(getActionConfig());
 } catch (error) {
-    core.setFailed(error.message);
+    const failOnError = core.getBooleanInput('fail-on-error');
+    const log = error.message;
+    if (failOnError) {
+        core.setFailed(log);
+    }
 }

--- a/src/post/index.js
+++ b/src/post/index.js
@@ -48,6 +48,10 @@ async function run(config) {
         return state.Status !== docker.CONTAINER_STATUS_EXITED;
     }, 1000, 30 * 1000);
 
+    if (logs.stderr !== '') {
+        throw new Error(logs.stderr);
+    }
+
     if (containerState.ExitCode !== 0) {
         throw new Error(`Container exited with error: ${containerState.ExitCode}`);
     }
@@ -58,5 +62,15 @@ async function run(config) {
 try {
     await run(getActionConfig());
 } catch (error) {
-    core.setFailed(error.message);
+    const failOnError = core.getBooleanInput('fail-on-error');
+    const log = error.message;
+    if (failOnError) {
+        core.setFailed(log);
+    } else {
+        await core.summary
+            .addHeading('Cimon Security Report - Failure')
+            .addRaw('Cimon encountered an error and was shut down due to the "fail-on-error=false" flag. Details of the error are below:')
+            .addCodeBlock(log)
+            .write()
+    }
 }


### PR DESCRIPTION
Even though the code is short, I spent some time thinking about how would be best to implement it.
In short, we have the `pre` script of Cimon and the `post` script.

The `pre` script can fail when we don't manage to reach the container's healthy state. If that happens, the CI will fail. For any other error the `pre` script will continue, and it will fail on the `post` script`.

In addition, the `post` script just outputs any log, including `stderr` the container had, so any possible error in the container (including the ones we had in `pre` script) would surface in `post` and fail the CI.

Having said that, I chosed to implement the `fail-on-error` flag in the following way:
- For `pre` script, if the container didn't reach healthy status, nothing will happen (not even a warning/error message)
- For `post` script, if any error happens, it will still return 0 (success), but will create a new job summary with the error message.

I also wanted to reduce the amount of annotation messages and make them more concrete, that's why `pre` script shows nothing, and for `post` script, if `stderr` exists, it will print him, or else just generic `container failed...` message.

You can see example for such run here: https://github.com/CycodeLabs/cimon-action/actions/runs/4712209939