### PR TITLE
chore: small chore changes (explained in pr description)

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -10,6 +10,7 @@ function getActionConfig() {
     const dockerPassword = core.getInput('docker-password');
 
     const token = core.getInput('github-token');
+    const reportJobSummary = core.getBooleanInput('report-job-summary');
 
     const logLevel = core.getInput('log-level');
     const preventionMode = core.getBooleanInput('prevent');
@@ -20,9 +21,7 @@ function getActionConfig() {
     const clientId = core.getInput('client-id');
     const secret = core.getInput('secret');
 
-    const reportJobSummary = core.getBooleanInput('report-job-summary');
     const reportProcessTree = core.getBooleanInput('report-process-tree');
-    const reportArtifactLog = core.getBooleanInput('report-artifact-log');
     const slackWebhookEndpoint = core.getInput('slack-webhook-endpoint');
     const featureGates = core.getMultilineInput('feature-gates');
 
@@ -35,6 +34,7 @@ function getActionConfig() {
         },
         github: {
             token: token,
+            jobSummary: reportJobSummary,
         },
         cimon: {
             logLevel: logLevel,
@@ -47,9 +47,7 @@ function getActionConfig() {
             featureGates: featureGates,
         },
         report: {
-            jobSummary: reportJobSummary,
             processTree: reportProcessTree,
-            artifactLog: reportArtifactLog,
             slackWebhookEndpoint: slackWebhookEndpoint,
         },
     };
@@ -103,11 +101,9 @@ async function run(config) {
 
     if (config.cimon.allowedHosts !== "") {
         args.push('--env', `CIMON_ALLOWED_HOSTS=${config.cimon.allowedHosts}`);
-        // TODO Remove the CIMON_ALLOWED_DOMAIN_NAMES setting when we upgrade the default image used by this action.
-        args.push('--env', `CIMON_ALLOWED_DOMAIN_NAMES=${config.cimon.allowedHosts}`);
     }
 
-    if (config.report.jobSummary) {
+    if (config.github.jobSummary) {
         args.push('--env', 'CIMON_REPORT_GITHUB_JOB_SUMMARY=1');
     }
 
@@ -135,7 +131,7 @@ async function run(config) {
         args.push('--env', `CIMON_FEATURE_GATES=${config.cimon.featureGates}`);
     }
 
-    
+
     args.push(config.docker.image);
 
     const exitCode = await exec.exec('docker', args, {

--- a/src/post/index.js
+++ b/src/post/index.js
@@ -63,10 +63,11 @@ try {
     await run(getActionConfig());
 } catch (error) {
     const failOnError = core.getBooleanInput('fail-on-error');
+    const reportJobSummary = core.getBooleanInput('report-job-summary');
     const log = error.message;
     if (failOnError) {
         core.setFailed(log);
-    } else {
+    } else if (reportJobSummary) {
         await core.summary
             .addHeading('Cimon Security Report - Failure')
             .addRaw('Cimon encountered an error and was shut down due to the "fail-on-error=false" flag. Details of the error are below:')


### PR DESCRIPTION
- removed `CIMON_ALLOWED_DOMAIN_NAMES` param completely
- moved report job summary parameter from report params, to github specific ones
- checking whether to allow job summary report before writing an error to it (when `fail-on-error` is false)
- removed artifact job log param from pre-script because he isn't needed there