### PR TITLE
fix: skip RC/alpha/beta tags when finding latest v1.x

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -27456,7 +27456,13 @@ async function getLatestV1Version() {
         if (!releases || releases.length === 0) break;
 
         for (const release of releases) {
-            if (release.tag_name && release.tag_name.startsWith('v1.') && !release.draft) {
+            // Match v1.x.y but skip v1.x.y-rc1, v1.x.y-alpha, etc.
+            // Pre-releases on GitHub are fine (our release workflow marks
+            // all v1.x as pre-release to not override v0 latest).
+            if (release.tag_name &&
+                release.tag_name.startsWith('v1.') &&
+                !release.draft &&
+                !release.tag_name.includes('-')) {
                 return release.tag_name;
             }
         }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -24,7 +24,13 @@ async function getLatestV1Version() {
         if (!releases || releases.length === 0) break;
 
         for (const release of releases) {
-            if (release.tag_name && release.tag_name.startsWith('v1.') && !release.draft) {
+            // Match v1.x.y but skip v1.x.y-rc1, v1.x.y-alpha, etc.
+            // Pre-releases on GitHub are fine (our release workflow marks
+            // all v1.x as pre-release to not override v0 latest).
+            if (release.tag_name &&
+                release.tag_name.startsWith('v1.') &&
+                !release.draft &&
+                !release.tag_name.includes('-')) {
                 return release.tag_name;
             }
         }


### PR DESCRIPTION
getLatestV1Version() was picking v1.0.9-rc1 over v1.0.9. Now skips tags containing '-'.