### PR TITLE
chore: bump action runtime to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,6 @@ inputs:
     required: false
 
 runs:
-  using: node20
+  using: node24
   main: 'dist/main/index.js'
   post: 'dist/post/index.js'

--- a/attest/action.yml
+++ b/attest/action.yml
@@ -87,5 +87,5 @@ inputs:
     default: 'false'
 
 runs:
-  using: node20
+  using: node24
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- Both `action.yml` files declared `using: node20`. GitHub is forcing Node 24 on hosted runners on **June 2, 2026** and removing Node 20 support on **September 16, 2026** — without this bump, the action breaks on that date.
- Two-line change: `node20` → `node24` in the root `action.yml` and `attest/action.yml`. No source/dist rebuild needed (action runtime is declared independently of the bundled JS).

## Risk
- **Self-hosted runners** must be on a version of `actions/runner` that ships Node 24. Customers on older runners will fail with "Node 24 not found." Same constraint applies to GHES.
- The bundled `dist/*.js` is `ncc`-transpiled; runtime-compatible with Node 24. The existing `scripts/fix-esm-require.js` shim (added in 1bec56a for Node 20+ ESM/require interop) remains effective.
- Plan to backport the same change to `v0.10.x` as `v0.10.1` so customers pinned to `@v0` are not stranded.

## Test plan
- [ ] `verify-pr` workflow passes on this PR
- [ ] Manually trigger or observe a downstream consumer using `@chore/node24-bump` (or wait for first run on a Node 24 runner post-merge)
- [ ] After merge, move the `v1` floating tag and announce the runner-version requirement to customers