### PR TITLE
chore: bump action runtime to node24 (v0 backport)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,6 @@ inputs:
     default: ''
 
 runs:
-  using: node20
+  using: node24
   main: 'dist/main/index.js'
   post: 'dist/post/index.js'

--- a/attest/action.yml
+++ b/attest/action.yml
@@ -87,5 +87,5 @@ inputs:
     default: 'false'
 
 runs:
-  using: node20
+  using: node24
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- Backport of #115 to the v0 maintenance line, branched from the `v0.10.0` tag.
- Same two-line change: `using: node20` → `using: node24` in `action.yml` and `attest/action.yml`.
- Without this, customers pinned to `@v0` / `@v0.10.0` break on **September 16, 2026** when GitHub removes Node 20 support.

## Why a v0 backport
- Customers pinned to `@v0` may be on v0 deliberately (haven't validated v1 hardening behavior, or v1 conflicts with their setup). Forcing them to v1 just to get a Node bump would couple the two changes unfairly.
- Pure runtime bump — no behavior change, no v1 features pulled in.

## Test plan
- [ ] `verify-pr` workflow passes on this PR
- [ ] After merge: tag `v0.10.1` on `release/v0`, move floating `v0` tag
- [ ] Announce runner-version requirement to customers (self-hosted / GHES need a runner that ships Node 24)