### PR TITLE
fix(attest): export install path so verify steps can find cimon

### DIFF
--- a/attest/action.yml
+++ b/attest/action.yml
@@ -86,6 +86,14 @@ inputs:
     required: false
     default: 'false'
 
+outputs:
+  cimon-path:
+    description: |
+      Absolute path to the installed cimon (or cimon.exe) binary used by
+      this action invocation. Downstream steps in the same job can also
+      reach the binary via the CIMON_PATH env var, or call `cimon` /
+      `cimon.exe` directly since the action adds the install dir to PATH.
+
 runs:
   using: node20
   main: 'dist/index.js'

--- a/attest/index.js
+++ b/attest/index.js
@@ -201,6 +201,18 @@ async function run(config) {
         releasePath = CIMON_EXECUTABLE_PATH;
     }
 
+    // Expose the installed binary location to downstream workflow steps so
+    // they don't have to reconstruct the per-job tmpdir layout. Three
+    // surfaces, each for a different consumption pattern:
+    //   - PATH: a later `cimon.exe attest verify ...` step just works.
+    //   - CIMON_PATH env var: an absolute path for callers that bypass PATH
+    //     (e.g. self-hosted runners with locked-down PATH lookup).
+    //   - step output `cimon-path`: chains cleanly into another job via
+    //     ${{ steps.<id>.outputs.cimon-path }}.
+    core.addPath(path.dirname(releasePath));
+    core.exportVariable('CIMON_PATH', releasePath);
+    core.setOutput('cimon-path', releasePath);
+
     if (config.attest.imageRef !== '') {
         core.warning(
             'image-ref parameter is deprecated and will be removed in future versions. Please use subjects parameter instead.'


### PR DESCRIPTION
## Summary

#114 scoped the action's install directory to ` \$RUNNER_TEMP/cimon-<run_id>-<run_attempt>-<job>/ ` as a security fix, but the docs and the customer-facing demo workflow still hardcode the pre-#114 path ` \$RUNNER_TEMP/cimon/ `. A naive ` cimon.exe attest verify ` step following the action now fails with ` cimon.exe not found `.

Fix: expose the install path three ways so workflows never reconstruct the per-job tmpdir layout:

1. ` core.addPath(dir) ` — ` cimon ` / ` cimon.exe ` resolves on PATH in the same job.
2. ` CIMON_PATH ` env var — absolute path, for callers that bypass PATH (locked-down self-hosted runners).
3. step output ` cimon-path ` — chains cleanly into other jobs via ` \${{ steps.<id>.outputs.cimon-path }} `.

Applies to all three install branches (Windows release-zip, Linux ` install.sh `, and the ` release-path ` input override).

## After this lands

The docs verify step in [docs/provenance/3-integrations/9-windows-ghes.md](https://github.com/CycodeLabs/cycodelabs.github.io/blob/main/docs/provenance/3-integrations/9-windows-ghes.md) and the [demo workflow](https://github.com/CycodeLabsDemo/cimon-demo-simple-app/blob/main/.github/workflows/ci-attest-windows-l3.yml) collapse from:

` ` `pwsh
\$exe = Join-Path \$env:RUNNER_TEMP 'cimon\cimon.exe'
& \$exe attest verify ...
` ` `

to just:

` ` `pwsh
cimon.exe attest verify ...
` ` `

## Test plan

- [x] ncc rebuild of ` attest/dist/index.js ` succeeds
- [ ] ` verify-attest-windows ` job in this PR's CI passes (and now exercises the new behavior end-to-end on ` windows-latest `)
- [ ] After merge: cut v1.0.1, move ` @v1 `, then update demo + docs to drop the path construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)